### PR TITLE
show nice error if mocked function wasn't called

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -93,12 +93,14 @@ mock_args <- function(x, call_no = mock_n_called(x)) {
 #' @export
 mock_arg <- function(x, arg, call_no = mock_n_called(x)) {
   stopifnot(is.character(arg), length(arg) == 1L)
+  if (call_no == 0)
+    stop("mocked function was never called")
   mock_arg_retriever(x, arg, call_no)
 }
 
 mock_arg_retriever <- function(x, arg, call_no) {
 
-  stopifnot(length(call_no) == 1L, is.numeric(call_no))
+  stopifnot(length(call_no) == 1L, is.numeric(call_no), call_no > 0)
 
   x <- singleton_list_to_mocked_fun(x)
 

--- a/tests/testthat/test-mock-fun.R
+++ b/tests/testthat/test-mock-fun.R
@@ -20,3 +20,13 @@ test_that("create and query mock_fun", {
   skip_if(getRversion() < "3.6.0")
   expect_identical(mock_call(mk), str2lang("curl::curl(url = url)"))
 })
+
+test_that("mock_arg errs if mocked function wasn't called", {
+  url <- "https://eu.httpbin.org/get?foo=123"
+  mk <- mock("mocked request")
+  with_mock(`curl::curl` = mk, {})
+  expect_error(
+    mock_arg(mk, "url"),
+    "mocked function was never called"
+  )
+})


### PR DESCRIPTION
The test case used to print this unhelpful error:
```
Error in get("args", envir = env)[[call_no]] :
  attempt to select less than one element in integerOneIndex
```
but now prints
```
mocked function was never called
```